### PR TITLE
fix: update github username in order to create release binary and fix plugin install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   release:
@@ -12,7 +12,6 @@ jobs:
     permissions:
       contents: write
     steps:
-
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -22,7 +21,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           cache: true
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - name: Download dependencies
         run: |
@@ -38,13 +37,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Useful if you want to use not the latest tag for changelog.
           GORELEASER_PREVIOUS_TAG: ""
-
-  docker-images:
-    name: Build Docker images
-    uses: ./.github/workflows/reusable-docker-images.yml
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   test-install:
     name: Test plugin installation

--- a/.github/workflows/reusable-test-install.yml
+++ b/.github/workflows/reusable-test-install.yml
@@ -8,7 +8,6 @@ jobs:
     name: Test plugin installation
     runs-on: ubuntu-latest
     steps:
-
       - name: Install helm
         run: |
           helm_version="3.15.2"
@@ -18,7 +17,7 @@ jobs:
           curl -sSL https://get.helm.sh/${tar_filename} -O
           curl -sSL https://get.helm.sh/${checksum_filename} -O
           cat ${checksum_filename} | sha256sum -c
-          
+
           tar xzf ${tar_filename}
           sudo mv linux-amd64/helm /usr/local/bin/helm
           rm -rf linux-amd64 ${tar_filename} ${checksum_filename}
@@ -33,4 +32,4 @@ jobs:
           fi
 
           echo "Check installation of version ${version}"
-          helm plugin install https://github.com/hypnoglow/helm-s3.git --version ${version}
+          helm plugin install https://github.com/chasinglogic/helm-s3.git --version ${version}

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 PROJECT_NAME="helm-s3"
-PROJECT_GH="hypnoglow/$PROJECT_NAME"
+PROJECT_GH="chasinglogic/$PROJECT_NAME"
 
 set -e
 set -u

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,13 +1,13 @@
 name: "s3"
-version: "0.16.1"
+version: "0.0.1"
 usage: "Manage chart repositories on Amazon S3"
 description: |-
   Provides AWS S3 protocol support for charts and repos. https://github.com/hypnoglow/helm-s3
 command: "$HELM_PLUGIN_DIR/bin/helm-s3"
 downloaders:
-- command: "bin/helm-s3 download"
-  protocols:
-    - "s3"
+  - command: "bin/helm-s3 download"
+    protocols:
+      - "s3"
 hooks:
   install: "cd $HELM_PLUGIN_DIR; ./hack/install.sh"
   update: "cd $HELM_PLUGIN_DIR; ./hack/install.sh"


### PR DESCRIPTION
Using `helm plugin install` currently installs the hypnoglow release binary.  Installing plugins works via the `plugin.yaml` file which specifies the install script `./hack/install.sh` to execute which had hard coded hypnoglow strings in it.

This is the absolute minimum hackery required to make a release, tested here https://github.com/lupinelab/helm-s3/actions/runs/11509107238, assuming you make a `v0.0.1` tag after this is merged.